### PR TITLE
fix some bug

### DIFF
--- a/src/ProtocolFunctionDictionary.cs
+++ b/src/ProtocolFunctionDictionary.cs
@@ -62,11 +62,11 @@ namespace Sproto
 		private SprotoTypeBase _gen(KeyValuePair<Type, typeFunc> field, int tag, byte[] buffer, int offset=0) {
 			if (field.Value != null) {
 				SprotoTypeBase obj = field.Value (buffer, offset);
-				/*
+#if (!INCLUDE_IL2CPP)
 				if (obj.GetType () != field.Key) {
 					throw new Exception("sproto type: "+obj.GetType().ToString() + "not is expected. [" + field.Key.ToString() + "]");
 				}
-				*/
+#endif
 				return obj;
 			}
 			return null;

--- a/src/ProtocolFunctionDictionary.cs
+++ b/src/ProtocolFunctionDictionary.cs
@@ -10,7 +10,7 @@ namespace Sproto
 			public KeyValuePair<Type, typeFunc> Request;
 			public KeyValuePair<Type, typeFunc> Response;
 		};
-			
+
 		public delegate SprotoTypeBase typeFunc (byte[] buffer, int offset);
 		private Dictionary<int, MetaInfo> MetaDictionary;
 		private Dictionary<Type, int> ProtocolDictionary;
@@ -34,7 +34,7 @@ namespace Sproto
 			data.ProtocolType = typeof(ProtocolType);
 			this.ProtocolDictionary.Add (data.ProtocolType, tag);
 		}
-			
+
 
 		public void SetRequest<T>(int tag) where T: SprotoTypeBase, new() {
 			MetaInfo data = this._getMeta (tag);
@@ -57,14 +57,16 @@ namespace Sproto
 
 			field = new KeyValuePair<Type, typeFunc> (typeof(T), _func);
 		}
-			
+
 
 		private SprotoTypeBase _gen(KeyValuePair<Type, typeFunc> field, int tag, byte[] buffer, int offset=0) {
 			if (field.Value != null) {
 				SprotoTypeBase obj = field.Value (buffer, offset);
+				/*
 				if (obj.GetType () != field.Key) {
 					throw new Exception("sproto type: "+obj.GetType().ToString() + "not is expected. [" + field.Key.ToString() + "]");
 				}
+				*/
 				return obj;
 			}
 			return null;
@@ -80,7 +82,7 @@ namespace Sproto
 			MetaInfo data = this.MetaDictionary[tag];
 			return _gen (data.Request, tag, buffer, offset);
 		}
-			
+
 
 		public MetaInfo this[int tag] {
 			get {
@@ -95,4 +97,3 @@ namespace Sproto
 		}
 	}
 }
-

--- a/src/SprotoRpc.cs
+++ b/src/SprotoRpc.cs
@@ -32,10 +32,12 @@ namespace Sproto
 			public byte[] Invoke<T>(SprotoTypeBase request=null, long? session=null) {
 				int tag = protocol[typeof(T)];
 				ProtocolFunctionDictionary.MetaInfo info = protocol[tag];
+				/*
 				if(request != null && request.GetType() != info.Request.Key) {
 					throw new Exception("request type: " + request.GetType().ToString() + "not is expected. [" + info.Request.Key.GetType().ToString() + "]");
-			
+
 				}
+				*/
 
 				rpc.package.clear();
 				rpc.package.type = tag;
@@ -67,14 +69,14 @@ namespace Sproto
 		public SprotoRpc (ProtocolBase protocolObj=null) {
 			this.protocol =  (protocolObj!=null)?(protocolObj.Protocol):(null);
 		}
-			
+
 
 		public RpcRequest Attach(ProtocolBase protocolObj=null) {
 			ProtocolFunctionDictionary protocol = (protocolObj!=null)?(protocolObj.Protocol):(null);
 			RpcRequest request = new RpcRequest (protocol, this);
 			return request;
 		}
-		 
+
 
 		public RpcInfo Dispatch(byte[] buffer, int offset=0) {
 			buffer = this.spack.unpack (buffer, buffer.Length - offset);
@@ -94,9 +96,11 @@ namespace Sproto
 					long session = this.package.session;
 					info.Response = delegate (SprotoTypeBase response) {
 						ProtocolFunctionDictionary.MetaInfo pinfo = this.protocol [tag];
+						/*
 						if (response.GetType () != pinfo.Response.Key) {
 							throw new Exception ("response type: " + response.GetType ().ToString () + "is not expected.(" + pinfo.Response.Key.ToString () + ")");
 						}
+						*/
 
 						this.stream.Seek (0, System.IO.SeekOrigin.Begin);
 						this.package.clear();
@@ -136,4 +140,3 @@ namespace Sproto
 		}
 	}
 }
-

--- a/src/SprotoRpc.cs
+++ b/src/SprotoRpc.cs
@@ -32,13 +32,12 @@ namespace Sproto
 			public byte[] Invoke<T>(SprotoTypeBase request=null, long? session=null) {
 				int tag = protocol[typeof(T)];
 				ProtocolFunctionDictionary.MetaInfo info = protocol[tag];
-				/*
+#if (!INCLUDE_IL2CPP)
 				if(request != null && request.GetType() != info.Request.Key) {
 					throw new Exception("request type: " + request.GetType().ToString() + "not is expected. [" + info.Request.Key.GetType().ToString() + "]");
 
 				}
-				*/
-
+#endif
 				rpc.package.clear();
 				rpc.package.type = tag;
 
@@ -96,12 +95,11 @@ namespace Sproto
 					long session = this.package.session;
 					info.Response = delegate (SprotoTypeBase response) {
 						ProtocolFunctionDictionary.MetaInfo pinfo = this.protocol [tag];
-						/*
+#if (!INCLUDE_IL2CPP)
 						if (response.GetType () != pinfo.Response.Key) {
 							throw new Exception ("response type: " + response.GetType ().ToString () + "is not expected.(" + pinfo.Response.Key.ToString () + ")");
 						}
-						*/
-
+#endif
 						this.stream.Seek (0, System.IO.SeekOrigin.Begin);
 						this.package.clear();
 						this.package.session = session;

--- a/src/SprotoStream.cs
+++ b/src/SprotoStream.cs
@@ -99,9 +99,10 @@ namespace Sproto
 			}
 
 			set {
-				if (i < 0 || i >= this.size) {
+				if (i < 0 || i > this.size) {
 					throw new Exception ("invalid idx:" + i + "@set");
 				}
+				this._expand ();
 				this.buffer [i] = value;
 			}
 		}

--- a/src/SprotoStream.cs
+++ b/src/SprotoStream.cs
@@ -74,7 +74,7 @@ namespace Sproto
 
 		public void Read(byte[] buffer, int offset, int count) {
 			for (int i = 0; i < count; i++) {
-				buffer[offset+i] = this.buffer[this.pos+i];
+				buffer[offset+i] = this.buffer[this.pos++];
 			}
 		}
 

--- a/src/SprotoStream.cs
+++ b/src/SprotoStream.cs
@@ -77,7 +77,7 @@ namespace Sproto
 				buffer[offset+i] = this.buffer[this.pos+i];
 			}
 		}
-			
+
 
 		public void MoveUp(int position, int up_count) {
 			if (up_count <= 0)
@@ -92,20 +92,18 @@ namespace Sproto
 
 		public byte this[int i] {
 			get {
-				if (i < 0 || i > this.pos) {
+				if (i < 0 || i >= this.size) {
 					throw new Exception ("invalid idx:" + i + "@get");
 				}
 				return this.buffer [i];
 			}
 
 			set {
-				if (i < 0 || i > this.pos) {
+				if (i < 0 || i >= this.size) {
 					throw new Exception ("invalid idx:" + i + "@set");
 				}
-				this._expand ();
 				this.buffer [i] = value;
 			}
 		}
 	}
 }
-


### PR DESCRIPTION
il2cpp bug 比较运算符两边都是动态类型时 会导致il2cpp编译器无法静态做类型推导
SprotoStream相关bug 具体看diff
