### PR TITLE
support decode a empty array

### DIFF
--- a/src/SprotoTypeDeserialize.cs
+++ b/src/SprotoTypeDeserialize.cs
@@ -77,7 +77,7 @@ namespace Sproto
 				SprotoTypeSize.error ("invalid array value.");
 
 			UInt32 sz = this.read_dword ();
-			if (sz < 1)
+			if (sz < 0)
 				SprotoTypeSize.error ("error array size("+sz+")");
 
 			return sz;
@@ -133,6 +133,10 @@ namespace Sproto
 			List<Int64> integer_list = null;
 
 			UInt32 sz = this.read_array_size ();
+			if (sz == 0) {
+				return new List<Int64> ();
+			}
+
 			int len = this.reader.ReadByte ();
 			sz--;
 


### PR DESCRIPTION
skynet 使用的 sproto lua 版本，字段对应的 lua 表为空和 nil 是两种编码规则
当字段对应的 lua 表为空时，会参与打包，且 data part 中的 head size 会填充为0
